### PR TITLE
Don't strip parsedocs.py from packages

### DIFF
--- a/package/genpackages
+++ b/package/genpackages
@@ -51,7 +51,7 @@ fi
 echo "Copying/Generating files"
 mkdir -p "$activedir/usr/share/ovm-ctl" &&
 cp ../*.py "../extra" "$activedir/usr/share/ovm-ctl" -r &&
-rm "$activedir/usr/share/ovm-ctl/"{parsedocs,gen_docs,man_writing}".py"
+rm "$activedir/usr/share/ovm-ctl/"{gen_docs,man_writing}".py"
 mkdir -p "$activedir/usr/bin" &&
 cp "../ovm-ctl" "$activedir/usr/bin" -r &&
 mkdir -p "$activedir/usr/share/man/man1" &&


### PR DESCRIPTION
As docs2dict resides in parsedocs, and is used for online help, excluding it
results in ImportError.
